### PR TITLE
Attach uploaded files in confirmation email

### DIFF
--- a/app/actions/email-actions.ts
+++ b/app/actions/email-actions.ts
@@ -5,7 +5,14 @@ import { LoopsClient } from "loops";
 
 const loops = new LoopsClient(process.env.LOOPS_API_KEY!);
 
-export async function sendConfirmationEmail(formData: FormData | GeneralFormData, claimNumber: string, pdfBase64: string) {
+export type Attachment = { filename: string; contentType: string; data: string }
+
+export async function sendConfirmationEmail(
+  formData: FormData | GeneralFormData,
+  claimNumber: string,
+  pdfBase64: string,
+  extraAttachments: Attachment[] = []
+) {
   console.log("Sending confirmation email... (base64 length)", pdfBase64.length)
   try {
      await loops.sendTransactionalEmail({
@@ -20,6 +27,7 @@ export async function sendConfirmationEmail(formData: FormData | GeneralFormData
           contentType: "application/pdf",
           data: pdfBase64,
         },
+        ...extraAttachments,
       ],
     });
     

--- a/components/claim/auto/claim-form-context.tsx
+++ b/components/claim/auto/claim-form-context.tsx
@@ -56,6 +56,7 @@ export type MediaFile = {
   url: string
   size: number
   thumbnail?: string
+  data?: string
   // buffer: Buffer
 }
 

--- a/components/claim/auto/steps/review-submit.tsx
+++ b/components/claim/auto/steps/review-submit.tsx
@@ -20,7 +20,7 @@ import {
 import { format } from "date-fns"
 import { toast } from "@/components/ui/use-toast"
 import { generateClaimAutoPDF } from "@/lib/generate-pdf"
-import { sendConfirmationEmail } from "@/app/actions/email-actions"
+import { sendConfirmationEmail, type Attachment } from "@/app/actions/email-actions"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 import Image from "next/image"
 import { useTranslations } from 'next-intl'
@@ -167,8 +167,43 @@ export default function ReviewSubmit() {
 
     try {
       // Convert pdfBuffer to base64 before sending
-      const base64 = Buffer.from(pdfBuffer).toString("base64");
-      const result = await sendConfirmationEmail(formData, claimNumber, base64)
+      const base64 = Buffer.from(pdfBuffer).toString("base64")
+
+      const attachments: Attachment[] = []
+      if (formData.friendlyReport && formData.friendlyReportDocument?.data) {
+        attachments.push({
+          filename: formData.friendlyReportDocument.name,
+          contentType: formData.friendlyReportDocument.type,
+          data: formData.friendlyReportDocument.data,
+        })
+      }
+
+      formData.damagePhotos.forEach((photo) => {
+        if (photo.data) {
+          attachments.push({
+            filename: photo.name,
+            contentType: photo.type,
+            data: photo.data,
+          })
+        }
+      })
+
+      formData.documents.forEach((doc) => {
+        if (doc.data) {
+          attachments.push({
+            filename: doc.name,
+            contentType: doc.type,
+            data: doc.data,
+          })
+        }
+      })
+
+      const result = await sendConfirmationEmail(
+        formData,
+        claimNumber,
+        base64,
+        attachments
+      )
 
       if (result.success) {
         setIsEmailSent(true)

--- a/components/claim/general/general-claim-form-context.tsx
+++ b/components/claim/general/general-claim-form-context.tsx
@@ -45,6 +45,7 @@ export type MediaFile = {
   url: string
   size: number
   thumbnail?: string
+  data?: string
   // buffer: Buffer
 }
 

--- a/components/ui/unified-upload.tsx
+++ b/components/ui/unified-upload.tsx
@@ -31,6 +31,7 @@ export type MediaFile = {
   url: string
   size: number
   thumbnail?: string
+  data?: string
   relativePath?: string // For directory uploads
 }
 
@@ -200,6 +201,19 @@ export function UnifiedUpload({
     })
   }
 
+  // Convert a File to a base64 string (without the data prefix)
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const result = reader.result as string
+        resolve(result.split(',')[1])
+      }
+      reader.onerror = () => reject(reader.error)
+      reader.readAsDataURL(file)
+    })
+  }
+
   // Handle files
   const handleFiles = async (selectedFiles: File[]) => {
     if (selectedFiles.length === 0) return
@@ -242,6 +256,8 @@ export function UnifiedUpload({
           thumbnail = await generateVideoThumbnail(file)
         }
 
+        const data = await fileToBase64(file)
+
         newFiles.push({
           id,
           name: file.name,
@@ -249,6 +265,7 @@ export function UnifiedUpload({
           url,
           size: file.size,
           thumbnail,
+          data,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           relativePath: (file as any).webkitRelativePath || (file as any).relativePath || undefined,
         })


### PR DESCRIPTION
## Summary
- collect base64 for uploaded files in `UnifiedUpload`
- store base64 data in claim form contexts
- allow `sendConfirmationEmail` to accept extra attachments
- attach all uploaded files from auto claim when sending confirmation email

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840168022008329a91bc48301763c4d